### PR TITLE
Progress_Bar.ino: Further testing. Small bug fix.

### DIFF
--- a/Main_Programming/Arduino/Arduino_Octomix/Progress_Bar.ino
+++ b/Main_Programming/Arduino/Arduino_Octomix/Progress_Bar.ino
@@ -32,7 +32,7 @@ void Progress_Bar(){
       Display_Write_Number("MIXMIX.progressBar.val=", floor(progress));
 
       // resets the global values for the next use of the progress bar 
-      if (progress >= 100){
+      if (progress >= 99){
         progress = 0;
         initProgress = true;
         mixSteps = 0;


### PR DESCRIPTION
 Reduced the number needed for a reset from 100 to 99. Otherwise crsMix with a small amount of mixSteps (~3) or with a bigger amount of mixSteps (~9) wouldn't work right (probably something rounding related.