### PR TITLE
cliScript update and Display_Com variable removed. 

### DIFF
--- a/Main_Programming/Arduino/Arduino_Octomix/Display_Com.ino
+++ b/Main_Programming/Arduino/Arduino_Octomix/Display_Com.ino
@@ -109,8 +109,6 @@ void Display_Write_Number(String command, int value){
 // command = the command you want to trigger 
 // value = value that you want to transmitt to the command 
 // for example: 1 or 0 for on/off
-  char mark='"';
-
   displaySerial.print(command);
   displaySerial.print(value);
     displaySerial.write(0X0ff);

--- a/Main_Programming/Arduino/Arduino_Octomix/cliScript.sh
+++ b/Main_Programming/Arduino/Arduino_Octomix/cliScript.sh
@@ -17,14 +17,17 @@ elif [ $options -eq 2 ]; then
 elif [ $options -eq 3 ] || [ $options -eq 4 ]; then
   echo "Baudrate: "
   echo "(1): 31250"
-  echo "(2): Custom"
+  echo "(2): 9600"
+  echo "(3): Custom"
   echo ""
   read baudrateOptions
 
   # Checks if you want a 31250 or a custom baudrate 
   if [ $baudrateOptions -eq 1 ]; then
     baudrate=31250
-  elif [ $baudrateOptions -eq 2 ]; then
+  elif [ $baudrateOptions -eq 1 ]; then
+    baudrate=9600
+  elif [ $baudrateOptions -eq 3 ]; then
     echo ""
     echo "Enter baudrate: "
     read baudrate


### PR DESCRIPTION
- cliScript has now 2 defautl options (3125, 9600 baud) and the third one is custom
- Removed an unnecessary variable fin Display_Com:
- char mark is not being used in Display_Write_Number()